### PR TITLE
Fix: Correct Tab 3 plot display using gr.Image

### DIFF
--- a/app.py
+++ b/app.py
@@ -990,7 +990,7 @@ with gr.Blocks() as astro_app:
             tab3_status_display = gr.Textbox(label="Processing Status / Errors", interactive=False, lines=8, elem_id="tab3_status_disp_extinction")
             gr.Markdown("### Results Plot & Data Table")
             with gr.Row():
-                tab3_plot_display = gr.Plot(label="Airmass vs. Magnitude Plot", visible=True, elem_id="tab3_extinction_plot") # Set visible=True or handle via output
+                tab3_plot_display = gr.Image(label="Airmass vs. Magnitude Plot", type="filepath", visible=True, elem_id="tab3_extinction_plot_img")
             with gr.Row():
                 tab3_results_table = gr.DataFrame(label="Photometry & Airmass Data", visible=True, headers=["Filename", "Airmass", "Instrumental_Magnitude", "Raw_Flux", "Net_Flux", "X_cen", "Y_cen", "Skipped_Reason"], wrap=True, elem_id="tab3_extinction_table")
 


### PR DESCRIPTION
Resolves an AttributeError that occurred when displaying the extinction plot in Tab 3. The error ('str' object has no attribute '__module__') was caused by passing a file path string (for the saved plot image) to a gr.Plot component, which expects a Matplotlib figure object.

This commit changes the `tab3_plot_display` component in `app.py` from `gr.Plot` to `gr.Image(type="filepath", ...)`. The `handle_tab3_extinction_from_fits` function already returns the file path of the generated PNG plot, which is the correct input type for `gr.Image`.

This change ensures the plot image is correctly displayed in the UI.